### PR TITLE
Save fullPath when node was already added and after moved to a child

### DIFF
--- a/tree.go
+++ b/tree.go
@@ -155,6 +155,7 @@ func (n *node) addRoute(path string, handlers HandlersChain) {
 					children:  n.children,
 					handlers:  n.handlers,
 					priority:  n.priority - 1,
+					fullPath:  n.fullPath,
 				}
 
 				// Update maxParams (max of all children)
@@ -236,6 +237,7 @@ func (n *node) addRoute(path string, handlers HandlersChain) {
 					panic("handlers are already registered for path '" + fullPath + "'")
 				}
 				n.handlers = handlers
+				n.fullPath = fullPath
 			}
 			return
 		}

--- a/tree_test.go
+++ b/tree_test.go
@@ -33,7 +33,7 @@ func checkRequests(t *testing.T, tree *node, requests testRequests, unescapes ..
 	}
 
 	for _, request := range requests {
-		handler, ps, _, _ := tree.getValue(request.path, nil, unescape)
+		handler, ps, rp, _ := tree.getValue(request.path, nil, unescape)
 
 		if handler == nil {
 			if !request.nilHandler {
@@ -45,6 +45,9 @@ func checkRequests(t *testing.T, tree *node, requests testRequests, unescapes ..
 			handler[0](nil)
 			if fakeHandlerValue != request.route {
 				t.Errorf("handle mismatch for route '%s': Wrong handle (%s != %s)", request.path, fakeHandlerValue, request.route)
+			}
+			if rp != request.route {
+				t.Errorf("full path mismatch, expected: \"%s\" got: \"%s\"", request.route, rp)
 			}
 		}
 


### PR DESCRIPTION
Here are 2 small changes where the `fullPath` should be saved. I added a little test in file `tree_test.go` function `checkRequest`. Doing so it is checking for all the routes used in the tests. Probably you should add a test to check if everything is working fine also with the `context`. gin-gonic/gin#1447